### PR TITLE
let g:vem_layout = current system layout

### DIFF
--- a/vemrc
+++ b/vemrc
@@ -14,7 +14,7 @@ set nocompatible
 let g:loaded_vem = 1
 
 " set keyboard layout. (possible values 'querty', 'qwertz', 'azerty')
-let g:vem_layout = system('setxkbmap -query | grep -o -E "(querty|quertz|azerty)$" || echo "querty"')[:-2]
+let g:vem_layout = system('asetxkbmap -query 2> /dev/null | grep -o -E "(querty|quertz|azerty)$" || echo "querty"')[:-2]
 
 " Vem directory
 let g:vem_dir = expand("<sfile>:p:h") . '/'

--- a/vemrc
+++ b/vemrc
@@ -13,8 +13,8 @@ set nocompatible
 " tell everybody Vem is being used
 let g:loaded_vem = 1
 
-" use querty by default (possible values 'querty', 'qwertz')
-let g:vem_layout = 'qwerty'
+" set keyboard layout. (possible values 'querty', 'qwertz', 'azerty')
+let g:vem_layout = system('setxkbmap -query | grep -o -E "(querty|quertz|azerty)$" || echo "querty"')[:-2]
 
 " Vem directory
 let g:vem_dir = expand("<sfile>:p:h") . '/'
@@ -73,4 +73,3 @@ exec 'source ' . s:vem_plugin_conf_dir . 'vim-surround.vim'
 exec 'source ' . s:vem_src_dir . 'custom-conf.vim'
 
 " And that's all!
-

--- a/vemrc
+++ b/vemrc
@@ -14,7 +14,7 @@ set nocompatible
 let g:loaded_vem = 1
 
 " set keyboard layout. (possible values 'querty', 'qwertz', 'azerty')
-let g:vem_layout = system('asetxkbmap -query 2> /dev/null | grep -o -E "(querty|quertz|azerty)$" || echo "querty"')[:-2]
+let g:vem_layout = system('asetxkbmap -query 2> /dev/null | grep -o -E "(qwerty|qwertz|azerty)$" || echo "qwerty"')[:-2]
 
 " Vem directory
 let g:vem_dir = expand("<sfile>:p:h") . '/'


### PR DESCRIPTION
with this change `let g:vem_layout` will be set at every vemrc sourcing to the system keyboard layout. 
I don't know if `setxkbmap` is installed on every system, it was on mine. if not it fallback to 'qwerty' anyway.
thanks